### PR TITLE
refactoring + testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "require": {
         "php": ">=5.4.0"
     },
+    "require-dev": {
+        "mockery/mockery": "dev-master"
+    },
     "autoload": {
         "psr-4": {
             "Mitch\\EventDispatcher\\": "src/"

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -3,54 +3,47 @@
 class Dispatcher
 {
     private $listeners = [];
-    private $sorted = [];
 
     public function dispatch($events)
     {
-        foreach ((array) $events as $event) {
+        if ( ! is_array($events)) {
+            return $this->fireEvent($events);
+        }
+
+        foreach ($events as $event) {
             $this->fireEvent($event);
         }
     }
 
-    public function listenOn($name, Listener $listener, $priority = 0)
+    public function listenOn($name, Listener $listener)
     {
-        $this->addListener($name, $listener, $priority);
+        $this->addListener($name, $listener);
     }
 
     private function fireEvent(Event $event)
     {
-        $name = $event->getName();
-        foreach ($this->getListeners($name) as $listener) {
-            call_user_func([$listener, 'handle'], $event);
+        $listeners = $this->getListeners($event->getName());
+
+        if ( ! $listeners) {
+            return;
+        }
+
+        foreach ($this->getListeners($event->getName()) as $listener) {
+            $listener->handle($event);
         }
     }
 
     private function getListeners($name)
     {
-        if ( ! isset($this->sorted[$name])) {
-            $this->sortListeners($name);
+        if ( ! isset($this->listeners[$name])) {
+            return;
         }
-        return $this->sorted[$name];
+
+        return $this->listeners[$name];
     }
 
-    private function sortListeners($name)
+    private function addListener($name, Listener $listener)
     {
-        $this->sorted[$name] = [];
-        if (isset($this->listeners[$name])) {
-            $sorted = $this->listeners[$name];
-            krsort($sorted);
-            $this->sorted[$name] = $sorted;
-        }
-    }
-
-    private function addListener($name, Listener $listener, $priority = 0)
-    {
-        $this->listeners[$name][$priority][] = $listener;
-        $this->clearSorted($name);
-    }
-
-    private function clearSorted($name)
-    {
-        unset($this->sorted[$name]);
+        $this->listeners[$name][] = $listener;
     }
 }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -1,0 +1,35 @@
+<?php 
+
+require_once('stubs/TestUserAddedEvent.php');
+
+use Mockery as m;
+
+class DispatcherTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->sut = new Mitch\EventDispatcher\Dispatcher;
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testCanCreateDispatcher()
+    {
+        $this->assertEquals('Mitch\EventDispatcher\Dispatcher', get_class($this->sut));
+    }
+
+    public function testCanDispatchEventToListener()
+    {
+        $event = new TestUserAddedEvent;
+
+        $listener = m::mock('Mitch\EventDispatcher\Listener');
+        $listener->shouldReceive('handle')->with($event)->andReturn(null)->once();
+
+        $this->sut->listenOn('accounts.user_added', $listener);
+
+        $this->sut->dispatch($event);
+    }
+} 

--- a/tests/stubs/TestUserAddedEvent.php
+++ b/tests/stubs/TestUserAddedEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+use Mitch\EventDispatcher\Event;
+
+class TestUserAddedEvent implements Event
+{
+    public function getName()
+    {
+        return 'accounts.user_added';
+    }
+}


### PR DESCRIPTION
remove priority from dispatcher
fix dispatcher bugs
add event stub for testing
begin dispatcher testing

the way that priority was being handled with array keys was causing some problems, i propose that if you want to use priority, then create value objects

a number of dispatcher bugs were fixed and i tried to simplify the code where possible

i created an event stub to prevent the need for a mock

i used mocking on listener to allow us to verify that the correct event was passed into it

i added mockery and started testing of the dispatcher
